### PR TITLE
Remove title from PROBLEM_REPORT.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
@@ -1,6 +1,5 @@
 name: Report a Problem
 description: Have you found something that does not work well, is too hard to do or is missing altogether? Please create a Problem Report.
-title: "Replace with a concise issue title"
 labels: ["needs triage"]
 body:
   - type: checkboxes


### PR DESCRIPTION
Removes optional title from issue template to avoid having to write a boilerplate issue title that reporters must always delete.